### PR TITLE
Fix Husky Pre-Commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     },
     "husky": {
         "hooks": {
-            "pre-commit": "pretty-quick --staged",
+            "pre-commit": "pretty-quick --staged --pattern \"**/*.*(js|jsx|ts|tsx)\"",
             "post-commit": "git update-index -g"
         }
     },


### PR DESCRIPTION
Configure the pre-commit hook command to restrict the Prettier formatter to JavaScript and TypeScript files only.