### PR TITLE
 Added comment on moving the 'Setup' tab to the 'Web' tab 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Check your antivirus hasn't blocked some parts of the ADB download - this has ha
 
 [![video Tutorial](https://img.youtube.com/vi/HspVa4i9rPg/0.jpg)](https://www.youtube.com/watch?v=HspVa4i9rPg)
 
-('Setup' tab was moved to the 'Web' tab under 'Setup & How-To')
+('Setup' tab was moved to the 'Setup & How-To' tab, inside the 'Web' tab)
 
 ## App Developers: 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check your antivirus hasn't blocked some parts of the ADB download - this has ha
 ## Video Tutorial
 
 [![video Tutorial](https://img.youtube.com/vi/HspVa4i9rPg/0.jpg)](https://www.youtube.com/watch?v=HspVa4i9rPg)
+
 ('Setup' tab was moved to the 'Web' tab under 'Setup & How-To')
 
 ## App Developers: 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check your antivirus hasn't blocked some parts of the ADB download - this has ha
 ## Video Tutorial
 
 [![video Tutorial](https://img.youtube.com/vi/HspVa4i9rPg/0.jpg)](https://www.youtube.com/watch?v=HspVa4i9rPg)
+('Setup' tab was moved to the 'Web' tab under 'Setup & How-To')
 
 ## App Developers: 
 


### PR DESCRIPTION
All the guides I could find online point to the 'Setup' tab which was moved to the 'Web' tab.
This makes it hard to find for newbies.
The following comment should point them in the right direction.