### PR TITLE
Adds Raspberry Pi instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,14 @@ yarn build --mac
 yarn build --wlm
 ```
 
-To build the app & angular app
+To build the app & angular app (NOT for Raspberry Pi)
 ```
 yarn dist
+```
+
+To build the app & angular app on a Raspberry Pi
+```
+yarn dist --armv7l
 ```
 
 To re-launch electron if you accidentally close it


### PR DESCRIPTION
We need to specify architecture when running `yarn dist`. Otherwise, the build will fail saying that ARM is not supported.